### PR TITLE
CORE-V: Support ALU Extension

### DIFF
--- a/gcc/common/config/riscv/riscv-common.cc
+++ b/gcc/common/config/riscv/riscv-common.cc
@@ -298,6 +298,8 @@ static const struct riscv_ext_version riscv_ext_version_table[] =
   {"xtheadmempair", ISA_SPEC_CLASS_NONE, 1, 0},
   {"xtheadsync", ISA_SPEC_CLASS_NONE, 1, 0},
 
+  {"xcvalu", ISA_SPEC_CLASS_NONE, 1, 0},
+
   /* Terminate the list.  */
   {NULL, ISA_SPEC_CLASS_NONE, 0, 0}
 };
@@ -1462,6 +1464,8 @@ static const riscv_ext_flag_table_t riscv_ext_flag_table[] =
   {"xtheadmemidx",  &gcc_options::x_riscv_xthead_subext, MASK_XTHEADMEMIDX},
   {"xtheadmempair", &gcc_options::x_riscv_xthead_subext, MASK_XTHEADMEMPAIR},
   {"xtheadsync",    &gcc_options::x_riscv_xthead_subext, MASK_XTHEADSYNC},
+
+  {"xcvalu", &gcc_options::x_riscv_xcv_flags, MASK_XCVALU},
 
   {NULL, NULL, 0}
 };

--- a/gcc/config/riscv/constraints.md
+++ b/gcc/config/riscv/constraints.md
@@ -118,6 +118,162 @@
   (and (match_operand 0 "move_operand")
        (match_test "CONSTANT_P (op)")))
 
+;; CORE-V Constraints
+(define_constraint "PALU31"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 1073741823")))
+
+(define_constraint "PALU30"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 536870911")))
+
+(define_constraint "PALU29"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 268435455")))
+
+(define_constraint "PALU28"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 134217727")))
+
+(define_constraint "PALU27"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 67108863")))
+
+(define_constraint "PALU26"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 33554431")))
+
+(define_constraint "PALU25"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 16777215")))
+
+(define_constraint "PALU24"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 8388607")))
+
+(define_constraint "PALU23"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 4194303")))
+
+(define_constraint "PALU22"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 2097151")))
+
+(define_constraint "PALU21"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 1048575")))
+
+(define_constraint "PALU20"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 524287")))
+
+(define_constraint "PALU19"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 262143")))
+
+(define_constraint "PALU18"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 131071")))
+
+(define_constraint "PALU17"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 65535")))
+
+(define_constraint "PALU16"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 32767")))
+
+(define_constraint "PALU15"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 16383")))
+
+(define_constraint "PALU14"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 8191")))
+
+(define_constraint "PALU13"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 4095")))
+
+(define_constraint "PALU12"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 2047")))
+
+(define_constraint "PALU11"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 1023")))
+
+(define_constraint "PALU10"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 511")))
+
+(define_constraint "PALU09"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 255")))
+
+(define_constraint "PALU08"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 127")))
+
+(define_constraint "PALU07"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 63")))
+
+(define_constraint "PALU06"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 31")))
+
+(define_constraint "PALU05"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 15")))
+
+(define_constraint "PALU04"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 7")))
+
+(define_constraint "PALU03"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 3")))
+
+(define_constraint "PALU02"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 1")))
+
+(define_constraint "PALU01"
+  "Checking for ALU clip if it's a power of 2"
+  (and (match_code "const_int")
+       (match_test "ival == 0")))
+
 ;; Vector constraints.
 
 (define_register_constraint "vr" "TARGET_VECTOR ? V_REGS : NO_REGS"

--- a/gcc/config/riscv/corev.def
+++ b/gcc/config/riscv/corev.def
@@ -1,0 +1,23 @@
+//XCVALU
+RISCV_BUILTIN (cv_alu_slet,     "cv_alu_slet",  RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI,     cvalu),
+RISCV_BUILTIN (cv_alu_sletu,    "cv_alu_sletu", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_USI_USI,   cvalu),
+RISCV_BUILTIN (cv_alu_min,      "cv_alu_min",   RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI,     cvalu),
+RISCV_BUILTIN (cv_alu_minu,     "cv_alu_minu",  RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI,  cvalu),
+RISCV_BUILTIN (cv_alu_max,      "cv_alu_max",   RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI,     cvalu),
+RISCV_BUILTIN (cv_alu_maxu,     "cv_alu_maxu",  RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI,  cvalu),
+
+RISCV_BUILTIN (cv_alu_exths,    "cv_alu_exths", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_HI,        cvalu),
+RISCV_BUILTIN (cv_alu_exthz,    "cv_alu_exthz", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_UHI,      cvalu),
+RISCV_BUILTIN (cv_alu_extbs,    "cv_alu_extbs", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_QI,        cvalu), 
+RISCV_BUILTIN (cv_alu_extbz,    "cv_alu_extbz", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_UQI,      cvalu),
+
+RISCV_BUILTIN (cv_alu_clip,     "cv_alu_clip",  RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI,     cvalu),
+RISCV_BUILTIN (cv_alu_clipu,    "cv_alu_clipu", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI,  cvalu),
+RISCV_BUILTIN (cv_alu_addN,     "cv_alu_addN",  RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI_UQI, cvalu),
+RISCV_BUILTIN (cv_alu_adduN,    "cv_alu_adduN", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI_UQI,  cvalu),
+RISCV_BUILTIN (cv_alu_addRN,    "cv_alu_addRN", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI_UQI, cvalu),
+RISCV_BUILTIN (cv_alu_adduRN,   "cv_alu_adduRN",RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI_UQI,  cvalu),
+RISCV_BUILTIN (cv_alu_subN,     "cv_alu_subN", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI_UQI, cvalu),
+RISCV_BUILTIN (cv_alu_subuN,    "cv_alu_subuN", RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI_UQI,  cvalu),
+RISCV_BUILTIN (cv_alu_subRN,    "cv_alu_subRN", RISCV_BUILTIN_DIRECT, RISCV_SI_FTYPE_SI_SI_UQI, cvalu),
+RISCV_BUILTIN (cv_alu_subuRN,   "cv_alu_subuRN",RISCV_BUILTIN_DIRECT, RISCV_USI_FTYPE_USI_USI_UQI,  cvalu),

--- a/gcc/config/riscv/corev.md
+++ b/gcc/config/riscv/corev.md
@@ -1,0 +1,340 @@
+;; Machine description for RISC-V CORE-V operations.
+;; Copyright (C) 2023 Free Software Foundation, Inc.
+
+;; This file is part of GCC.
+
+;; GCC is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; GCC is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GCC; see the file COPYING3.  If not see
+;; <http://www.gnu.org/licenses/>.
+
+(define_c_enum "unspec" [
+
+  ;;CORE-V ALU
+  UNSPEC_CV_ALU_CLIP
+  UNSPEC_CV_ALU_CLIPR
+  UNSPEC_CV_ALU_CLIPU
+  UNSPEC_CV_ALU_CLIPUR
+  UNSPEC_CV_ALU_ADDN
+  UNSPEC_CV_ALU_ADDUN
+  UNSPEC_CV_ALU_ADDRN
+  UNSPEC_CV_ALU_ADDURN
+  UNSPEC_CV_ALU_SUBN
+  UNSPEC_CV_ALU_SUBUN
+  UNSPEC_CV_ALU_SUBRN
+  UNSPEC_CV_ALU_SUBURN
+  UNSPEC_CV_ALU_EXTHS
+  UNSPEC_CV_ALU_EXTHZ
+  UNSPEC_CV_ALU_EXTBS
+  UNSPEC_CV_ALU_EXTBZ
+])
+
+;; CORE-V ALU builtins
+(define_insn "riscv_cv_alu_slet"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (if_then_else (gt:SI (match_operand:SI 1 "register_operand" "r") (match_operand:SI 2 "register_operand" "r")) (const_int 0) (const_int 1)))]
+  
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.slet\t%0, %1, %2" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_sletu"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (if_then_else (gtu:SI (match_operand:SI 1 "register_operand" "r") (match_operand:SI 2 "register_operand" "r")) (const_int 0) (const_int 1)))]
+  
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.sletu \t%0, %1, %2" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_min"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (if_then_else (gt:SI (match_operand:SI 1 "register_operand" "r") (match_operand:SI 2 "register_operand" "r")) (match_dup:SI 2) (match_dup:SI 1)))]
+  
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.min\t%0, %1, %2" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_minu"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (if_then_else (gtu:SI (match_operand:SI 1 "register_operand" "r") (match_operand:SI 2 "register_operand" "r")) (match_dup:SI 2) (match_dup:SI 1)))]
+  
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.minu\t%0, %1, %2" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_max"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (if_then_else (gt:SI (match_operand:SI 1 "register_operand" "r") (match_operand:SI 2 "register_operand" "r")) (match_dup:SI 1) (match_dup:SI 2)))]
+  
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.max\t%0, %1, %2" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_maxu"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (if_then_else (gtu:SI (match_operand:SI 1 "register_operand" "r") (match_operand:SI 2 "register_operand" "r")) (match_dup:SI 1) (match_dup:SI 2)))]
+  
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.maxu\t%0, %1, %2" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_exths"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (unspec:SI [(match_operand:HI 1 "register_operand" "r")]
+    UNSPEC_CV_ALU_EXTHS))]
+
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.exths\t%0, %1" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_exthz"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (unspec:SI [(match_operand:HI 1 "register_operand" "r")]
+    UNSPEC_CV_ALU_EXTHZ))]
+	
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.exthz\t%0, %1" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_extbs"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (unspec:SI [(match_operand:QI 1 "register_operand" "r")]
+    UNSPEC_CV_ALU_EXTBS))]
+
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.extbs\t%0, %1" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_extbz"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+  (unspec:SI [(match_operand:QI 1 "register_operand" "r")]
+    UNSPEC_CV_ALU_EXTBZ))] 
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "cv.extbz\t%0, %1" 
+  
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_clip"
+  [(set (match_operand:SI 0 "register_operand" "=r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r") (match_operand:SI 2 "immediate_register_operand" "PALU31,PALU30,PALU29,PALU28,PALU27,PALU26,PALU25,PALU24,PALU23,PALU22,PALU21,PALU20,PALU19,PALU18,PALU17,PALU16,PALU15,PALU14,PALU13,PALU12,PALU11,PALU10,PALU09,PALU08,PALU07,PALU06,PALU05,PALU04,PALU03,PALU02,PALU01,r")]
+    UNSPEC_CV_ALU_CLIP))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.clip\t%0,%1,31
+  cv.clip\t%0,%1,30
+  cv.clip\t%0,%1,29
+  cv.clip\t%0,%1,28
+  cv.clip\t%0,%1,27
+  cv.clip\t%0,%1,26
+  cv.clip\t%0,%1,25
+  cv.clip\t%0,%1,24
+  cv.clip\t%0,%1,23
+  cv.clip\t%0,%1,22
+  cv.clip\t%0,%1,21
+  cv.clip\t%0,%1,20
+  cv.clip\t%0,%1,19
+  cv.clip\t%0,%1,18
+  cv.clip\t%0,%1,17
+  cv.clip\t%0,%1,16
+  cv.clip\t%0,%1,15
+  cv.clip\t%0,%1,14
+  cv.clip\t%0,%1,13
+  cv.clip\t%0,%1,12
+  cv.clip\t%0,%1,11
+  cv.clip\t%0,%1,10
+  cv.clip\t%0,%1,9
+  cv.clip\t%0,%1,8
+  cv.clip\t%0,%1,7
+  cv.clip\t%0,%1,6
+  cv.clip\t%0,%1,5
+  cv.clip\t%0,%1,4
+  cv.clip\t%0,%1,3
+  cv.clip\t%0,%1,2
+  cv.clip\t%0,%1,1
+  cv.clipr\t%0,%1,%2"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+
+(define_insn "riscv_cv_alu_clipu"
+  [(set (match_operand:SI 0 "register_operand" "=r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,r,r,r,r,r,,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r") (match_operand:SI 2 "immediate_register_operand" "PALU31,PALU30,PALU29,PALU28,PALU27,PALU26,PALU25,PALU24,PALU23,PALU22,PALU21,PALU20,PALU19,PALU18,PALU17,PALU16,PALU15,PALU14,PALU13,PALU12,PALU11,PALU10,PALU09,PALU08,PALU07,PALU06,PALU05,PALU04,PALU03,PALU02,PALU01,r")]
+    UNSPEC_CV_ALU_CLIPU))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.clipu\t%0,%1,31
+  cv.clipu\t%0,%1,30
+  cv.clipu\t%0,%1,29
+  cv.clipu\t%0,%1,28
+  cv.clipu\t%0,%1,27
+  cv.clipu\t%0,%1,26
+  cv.clipu\t%0,%1,25
+  cv.clipu\t%0,%1,24
+  cv.clipu\t%0,%1,23
+  cv.clipu\t%0,%1,22
+  cv.clipu\t%0,%1,21
+  cv.clipu\t%0,%1,20
+  cv.clipu\t%0,%1,19
+  cv.clipu\t%0,%1,18
+  cv.clipu\t%0,%1,17
+  cv.clipu\t%0,%1,16
+  cv.clipu\t%0,%1,15
+  cv.clipu\t%0,%1,14
+  cv.clipu\t%0,%1,13
+  cv.clipu\t%0,%1,12
+  cv.clipu\t%0,%1,11
+  cv.clipu\t%0,%1,10
+  cv.clipu\t%0,%1,9
+  cv.clipu\t%0,%1,8
+  cv.clipu\t%0,%1,7
+  cv.clipu\t%0,%1,6
+  cv.clipu\t%0,%1,5
+  cv.clipu\t%0,%1,4
+  cv.clipu\t%0,%1,3
+  cv.clipu\t%0,%1,2
+  cv.clipu\t%0,%1,1
+  cv.clipur\t%0,%1,%2"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_addN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+                      (match_operand:SI 2 "register_operand" "r,r")
+                      (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_ADDN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.addN\t%0,%1,%2,%3
+  cv.addNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+(define_insn "riscv_cv_alu_adduN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+					(match_operand:SI 2 "register_operand" "r,r")
+					(match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_ADDUN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.adduN\t%0,%1,%2,%3
+  cv.adduNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+  (define_insn "riscv_cv_alu_addRN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+  (match_operand:SI 2 "register_operand" "r,r") 
+  (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_ADDRN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.addRN\t%0,%1,%2,%3
+  cv.addRNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+  (define_insn "riscv_cv_alu_adduRN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+  (match_operand:SI 2 "register_operand" "r,r") 
+  (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_ADDURN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.adduRN\t%0,%1,%2,%3
+  cv.adduRNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+  (define_insn "riscv_cv_alu_subN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+  (match_operand:SI 2 "register_operand" "r,r") 
+  (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_SUBN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.subN\t%0,%1,%2,%3
+  cv.subNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+  (define_insn "riscv_cv_alu_subuN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+  (match_operand:SI 2 "register_operand" "r,r")
+  (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_SUBUN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.subuN\t%0,%1,%2,%3
+  cv.subuNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+  (define_insn "riscv_cv_alu_subRN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+  (match_operand:SI 2 "register_operand" "r,r") 
+  (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_SUBRN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.subRN\t%0,%1,%2,%3
+  cv.subRNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])
+
+  (define_insn "riscv_cv_alu_subuRN"
+  [(set (match_operand:SI 0 "register_operand" "=r,r")
+  (unspec:SI [(match_operand:SI 1 "register_operand" "r,0")
+  (match_operand:SI 2 "register_operand" "r,r") 
+  (match_operand:QI 3 "csr_operand" "K,r")]
+    UNSPEC_CV_ALU_SUBURN))]
+  "TARGET_XCVALU && !TARGET_64BIT"
+  "@
+  cv.subuRN\t%0,%1,%2,%3
+  cv.subuRNr\t%0,%2,%3"
+
+  [(set_attr "type" "arith")
+  (set_attr "mode" "SI")])

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -275,6 +275,11 @@
 	return true;
 })
 
+;;CORE-V Predicates:
+(define_predicate "immediate_register_operand"
+  (ior (match_operand 0 "register_operand")
+       (match_code "const_int")))
+
 ;; Predicates for the V extension.
 (define_special_predicate "vector_length_operand"
   (ior (match_operand 0 "pmode_register_operand")

--- a/gcc/config/riscv/riscv-builtins.cc
+++ b/gcc/config/riscv/riscv-builtins.cc
@@ -124,6 +124,9 @@ AVAIL (clmulr_zbc32, TARGET_ZBC && !TARGET_64BIT)
 AVAIL (clmulr_zbc64, TARGET_ZBC && TARGET_64BIT)
 AVAIL (always,     (!0))
 
+//COREV AVAIL
+AVAIL (cvalu, TARGET_XCVALU && !TARGET_64BIT)
+
 /* Construct a riscv_builtin_description from the given arguments.
 
    INSN is the name of the associated instruction pattern, without the

--- a/gcc/config/riscv/riscv-opts.h
+++ b/gcc/config/riscv/riscv-opts.h
@@ -319,4 +319,8 @@ enum riscv_entity
 #define TARGET_VECTOR_VLS                                                      \
   (TARGET_VECTOR && riscv_autovec_preference == RVV_SCALABLE)
 
+#define MASK_XCVALU    (1 <<  0)
+
+#define TARGET_XCVALU     ((riscv_xcv_flags & MASK_XCVALU) != 0)
+
 #endif /* ! GCC_RISCV_OPTS_H */

--- a/gcc/config/riscv/riscv.opt
+++ b/gcc/config/riscv/riscv.opt
@@ -254,6 +254,9 @@ int riscv_ztso_subext
 TargetVariable
 int riscv_xthead_subext
 
+TargetVariable
+int riscv_xcv_flags
+
 Enum
 Name(isa_spec_class) Type(enum riscv_isa_spec_class)
 Supported ISA specs (for use with the -misa-spec= option):

--- a/gcc/doc/extend.texi
+++ b/gcc/doc/extend.texi
@@ -21614,6 +21614,100 @@ vector intrinsic specification, which is available at the following link:
 @uref{https://github.com/riscv-non-isa/rvv-intrinsic-doc/tree/v0.11.x}.
 All of these functions are declared in the include file @file{riscv_vector.h}.
 
+These built-in functions are available for the CORE-V ALU machine
+architecture. For more information on CORE-V built-ins, please see
+@uref{https://github.com/openhwgroup/core-v-sw/blob/master/specifications/corev-builtin-spec.md#listing-of-miscellaneous-alu-builtins-xcvalu}
+
+@deftypefn {Built-in Function} {int} __builtin_riscv_cv_alu_slet (int32_t, int32_t)
+Generated assembler @code{cv.slet}
+@end deftypefn
+
+@deftypefn {Built-in Function} {int} __builtin_riscv_cv_alu_sletu (uint32_t, uint32_t)
+Generated assembler @code{cv.sletu}
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_min (int32_t, int32_t)
+Generated assembler @code{cv.min}
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_minu (uint32_t, uint32_t)
+Generated assembler @code{cv.minu}
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_max (int32_t, int32_t)
+Generated assembler @code{cv.max}
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_tnt} __builtin_riscv_cv_alu_maxu (uint32_t, uint32_t)
+Generated assembler @code{cv.maxu}
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_exths (int16_t)
+Generated assembler @code{cv.exths}
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_exthz (uint16_t)
+Generated assembler @code{cv.exthz}
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_extbs (int8_t)
+Generated assembler @code{cv.extbs}
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_extbz (uint8_t)
+Generated assembler @code{cv.extbz}
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_clip (int32_t, uint32_t)
+Generated assembler @code{cv.clip} if the uint32_t operand is a constant and an exact power of 2.
+Generated assembler @code{cv.clipr} if  the it is a register.
+@end deftypefn
+ 
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_clipu (uint32_t, uint32_t)
+Generated assembler @code{cv.clipu} if the uint32_t operand is a constant and an exact power of 2.
+Generated assembler @code{cv.clipur} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_addN (int32_t, int32_t, uint8_t)
+Generated assembler @code{cv.addN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.addNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_adduN (uint32_t, uint32_t, uint8_t)
+Generated assembler @code{cv.adduN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.adduNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_addRN (int32_t, int32_t, uint8_t)
+Generated assembler @code{cv.addRN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.addRNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_adduRN (uint32_t, uint32_t, uint8_t)
+Generated assembler @code{cv.adduRN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.adduRNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_subN (int32_t, int32_t, uint8_t)
+Generated assembler @code{cv.subN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.subNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_subuN (uint32_t, uint32_t, uint8_t)
+Generated assembler @code{cv.subuN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.subuNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {int32_t} __builtin_riscv_cv_alu_subRN (int32_t, int32_t, uint8_t)
+Generated assembler @code{cv.subRN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.subRNr} if  the it is a register.
+@end deftypefn
+
+@deftypefn {Built-in Function} {uint32_t} __builtin_riscv_cv_alu_subuRN (uint32_t, uint32_t, uint8_t)
+Generated assembler @code{cv.subuRN} if the uint8_t operand is a constant and in the range 0 <= shft <= 31.
+Generated assembler @code{cv.subuRNr} if  the it is a register.
+@end deftypefn
+
 @node RX Built-in Functions
 @subsection RX Built-in Functions
 GCC supports some of the RX instructions which cannot be expressed in

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-compile.c
@@ -1,0 +1,222 @@
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+#include <stdint.h>
+
+extern int d;
+extern int e;
+extern int f;
+
+void foo0(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_addN (a, b, 0);
+  e = __builtin_riscv_cv_alu_addN (a, b, 7);
+  f = __builtin_riscv_cv_alu_addN (a, b, 31);
+}
+
+void foo1(int a, int b, int c)
+{
+  d = __builtin_riscv_cv_alu_addN (a, b, c);
+}
+
+void foo2(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_addRN (a, b, 0);
+  e = __builtin_riscv_cv_alu_addRN (a, b, 7);
+  f = __builtin_riscv_cv_alu_addRN (a, b, 31);
+}
+
+int foo3(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_addRN (a, b, c);
+}
+
+void foo4(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_adduN (a, b, 0);
+  e = __builtin_riscv_cv_alu_adduN (a, b, 7);
+  f = __builtin_riscv_cv_alu_adduN (a, b, 31);
+}
+
+int foo5(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_adduN (a, b, c);
+}
+
+void foo6(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_adduRN (a, b, 0);
+  e = __builtin_riscv_cv_alu_adduRN (a, b, 7);
+  f = __builtin_riscv_cv_alu_adduRN (a, b, 31);
+}
+
+int foo7(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_adduRN (a, b, c);
+}
+
+int foo8(int a, int b)
+{
+  return __builtin_riscv_cv_alu_clip (a, 15);
+}
+
+int foo9(int a, int b)
+{
+  return __builtin_riscv_cv_alu_clip (a, 10);
+}
+
+int foo10(int a, int b)
+{
+  return __builtin_riscv_cv_alu_clipu (a, 15);
+}
+
+int foo11(int a, int b)
+{
+  return __builtin_riscv_cv_alu_clipu (a, 10);
+}
+
+int foo12(int a)
+{
+  return __builtin_riscv_cv_alu_extbs (a);
+}
+
+int foo13(int a)
+{
+  return __builtin_riscv_cv_alu_extbz (a);
+}
+
+int foo14(int b)
+{
+  return __builtin_riscv_cv_alu_exths (b);
+}
+
+int foo15(int a)
+{
+  return __builtin_riscv_cv_alu_exthz (a);
+}
+
+int foo16(int a, int b)
+{
+  return __builtin_riscv_cv_alu_max (a, b);
+}
+
+int foo17(int a, int b)
+{
+  return __builtin_riscv_cv_alu_maxu (a, b);
+}
+
+int foo18(int a, int b)
+{
+  return __builtin_riscv_cv_alu_min (a, b);
+}
+
+int foo19(int a, int b)
+{
+  return __builtin_riscv_cv_alu_minu (a, b);
+}
+
+int foo20(int a, int b)
+{
+  return __builtin_riscv_cv_alu_slet (a, b);
+}
+
+int foo21(unsigned int a, unsigned int b)
+{
+  return __builtin_riscv_cv_alu_sletu (a, b);
+}
+
+void foo22(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subN (a, b, 0);
+  e = __builtin_riscv_cv_alu_subN (a, b, 7);
+  f = __builtin_riscv_cv_alu_subN (a, b, 31);
+}
+
+int foo23(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_subN (a, b, c);
+}
+
+void foo24(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subRN (a, b, 0);
+  e = __builtin_riscv_cv_alu_subRN (a, b, 7);
+  f = __builtin_riscv_cv_alu_subRN (a, b, 31);
+}
+
+int foo25(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_subRN (a, b, c);
+}
+
+void foo26(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subuN (a, b, 0);
+  e = __builtin_riscv_cv_alu_subuN (a, b, 7);
+  f = __builtin_riscv_cv_alu_subuN (a, b, 31);
+}
+
+int foo27(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_subuN (a, b, c);
+}
+
+void foo28(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subuRN (a, b, 0);
+  e = __builtin_riscv_cv_alu_subuRN (a, b, 7);
+  f = __builtin_riscv_cv_alu_subuRN (a, b, 31);
+}
+
+int foo29(int a, int b, int c)
+{
+  return __builtin_riscv_cv_alu_subuRN (a, b, c);
+}
+
+/* { dg-final { scan-assembler-times "cv\.addN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.addN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.addN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.addNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.addRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.addRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.addRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.addRNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.adduN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.adduN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.adduN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.adduNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.adduRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.adduRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.adduRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.adduRNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.clip\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),5" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.clipr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.clipu\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),5" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.clipur" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.extbs" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.extbz" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.exths" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.exthz" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.max" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.maxu" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.min" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.minu" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.slet" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.sletu" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.subNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.subRNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subuN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subuN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subuN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.subuNr" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subuRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),0" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subuRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),7" 1 } } */
+/* { dg-final { scan-assembler-times "cv\.subuRN\t\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),\(\?\:t\[0-6\]\|a\[0-7\]\|s\[1-11\]\),31" 1 } } */
+/* { dg-final { scan-assembler-times "cv\\.subuRNr" 1 } } */

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addn.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_addN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addrn.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_addRN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addun.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_adduN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addurn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-addurn.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_adduRN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clip.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clip.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_clip (a, 4294967296); /* { dg-warning "overflow in conversion from \'long long int\' to \'int\' changes value from \'4294967296\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clipu.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-clipu.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_clipu (a, 4294967296); /* { dg-warning "unsigned conversion from \'long long int\' to \'unsigned int\' changes value from \'4294967296\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subn.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subrn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subrn.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subRN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subun.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-subun.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subuN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-suburn.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile-suburn.c
@@ -1,0 +1,11 @@
+
+/* { dg-do compile } */
+/* { dg-require-effective-target cv_alu } */
+/* { dg-options "-march=rv32i_xcvalu -mabi=ilp32" } */
+
+extern int d;
+
+void foo1(int a, int b)
+{
+  d = __builtin_riscv_cv_alu_subuRN (a, b, 65536); /* { dg-warning "unsigned conversion from \'int\' to \'unsigned char\' changes value from \'65536\' to \'0\'" } */
+}

--- a/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile.c
+++ b/gcc/testsuite/gcc.target/riscv/cv-march-xcvalu-fail-compile.c
@@ -1,0 +1,30 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32i -mabi=ilp32" } */
+
+extern int d;
+
+int foo1(int a, int b, int c)
+{
+    d += __builtin_riscv_cv_alu_slet (a, b); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_sletu (a, b);  /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_addN (a, b, 31);  /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_addRN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_adduN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_adduRN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_clip (a, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_clipu (a, 35); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_extbs (a); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_extbz (a); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_exths (a); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_exthz (a); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_min (a, b); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_minu (a, b); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_max (a, b); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_maxu (a, b); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_subN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_subRN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_subuN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+    d += __builtin_riscv_cv_alu_subuRN (a, b, 31); /* { dg-warning "implicit declaration of function" } */
+
+    return d;
+}

--- a/gcc/testsuite/lib/target-supports.exp
+++ b/gcc/testsuite/lib/target-supports.exp
@@ -12563,6 +12563,20 @@ proc check_effective_target_const_volatile_readonly_section { } {
   return 1
 }
 
+# Return 1 if CORE-V architecture is available.
+
+proc check_effective_target_cv_alu { } {
+    if { !([istarget riscv*-*-*]) } {
+         return 0
+     }
+    return [check_no_compiler_messages cv_alu object {
+        void foo (void)
+        {
+          asm ("cv.addN t0, t1, t2, 0");
+        }
+    } "-march=rv32i_xcvalu" ]
+}
+
 # Appends necessary Python flags to extra-tool-flags if Python.h is supported.
 # Otherwise, modifies dg-do-what.
 proc dg-require-python-h { args } {


### PR DESCRIPTION
This PR presents the comprehensive implementation of the MAC extension for CORE-V, in preparation for upstream.

I have thoroughly tested the implementation to ensure its correctness and compatibility with the existing codebase. However, your input, reviews, and suggestions are invaluable in making this extension even more robust.

Test results (using [this](https://github.com/riscv-collab/riscv-gnu-toolchain) toolchain):

Category | Baseline | With commit | Comparison
-- | -- | -- | --
Expected passes |158326 | 158473 | +147 |
Unexpected failures | 68 | 68 | - |
Unexpected successes | 3 | 3 | - |
Expected failures | 899 | 899 | - |
Unresolved testcases | 4 | 4 | - |
Unsupported tests | 6641 | 6718 | +77 |

Multilib enabled:

Category | Baseline | With commit | Comparison
-- | -- | -- | --
Expected passes | 1112504 | 1113533 | +1029 |
Unexpected failures | 1021 | 1021 | - |
Unexpected successes | 23 | 23 | - |
Expected failures | 6295 | 6295 | - |
Unresolved testcases | 116 | 116 | - |
Unsupported tests | 44779 | 45318 | +539 |

TODO: The failures + unsupported tests are due to...